### PR TITLE
Add github icon and link on table page

### DIFF
--- a/daily_show_guests/app/views/guests/list.html.erb
+++ b/daily_show_guests/app/views/guests/list.html.erb
@@ -18,7 +18,12 @@
 <%= render "shared/search" %>
 <div class="container">
   <div class="page-header">
-    <h1>Daily Show Guests <small>data from fivethirtyeight</small></h1>
+    <h1>Daily Show Guests
+      <small>data from fivethirtyeight</small>
+      <a href="https://github.com/fivethirtyeight/data/tree/master/daily-show-guests" target="_blank">
+        <i class="fa fa-github-square"></i>
+      </a>
+    </h1>
   </div>
 </div>
 <div class="container">


### PR DESCRIPTION
Thought it'd look nice and be helpful to have a link to the original dataset
<img width="1177" alt="dailyshowguests" src="https://cloud.githubusercontent.com/assets/16456162/13374606/7399111e-dd4f-11e5-837a-467dd61b46ab.png">
